### PR TITLE
feat(deploy): add flag that allows for setting application name outside of deployment yaml

### DIFF
--- a/cmd/deploy/start.go
+++ b/cmd/deploy/start.go
@@ -22,7 +22,8 @@ const (
 
 type deployStartOptions struct {
 	*deployOptions
-	deploymentFile string
+	deploymentFile  string
+	applicationName string
 }
 
 type FormattableDeployStartResponse struct {
@@ -72,6 +73,7 @@ func NewDeployStartCmd(deployOptions *deployOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&options.deploymentFile, "file", "f", "", "path to the deployment file")
+	cmd.Flags().StringVarP(&options.applicationName, "application-name", "n", "", "application name for deployment")
 	cmd.MarkFlagRequired("file")
 	return cmd
 }
@@ -95,7 +97,19 @@ func start(cmd *cobra.Command, options *deployStartOptions, args []string) error
 	if err != nil {
 		return fmt.Errorf("error invalid deployment object: %s", err)
 	}
-	dep, err := deployment.CreateDeploymentRequest(&payload)
+	applicationNameOpt := options.applicationName
+	var applicationName string
+	if len(applicationNameOpt) > 0 {
+		applicationName = applicationNameOpt
+	} else {
+		applicationName = payload.Application
+	}
+
+	if len(applicationName) < 1 {
+		return fmt.Errorf("application name must be defined in deployment file or by application-name opt")
+	}
+
+	dep, err := deployment.CreateDeploymentRequest(applicationName, &payload)
 	if err != nil {
 		return fmt.Errorf("error converting deployment object: %s", err)
 	}

--- a/cmd/deploy/start.go
+++ b/cmd/deploy/start.go
@@ -22,8 +22,8 @@ const (
 
 type deployStartOptions struct {
 	*deployOptions
-	deploymentFile  string
-	applicationName string
+	deploymentFile string
+	application    string
 }
 
 type FormattableDeployStartResponse struct {
@@ -73,7 +73,7 @@ func NewDeployStartCmd(deployOptions *deployOptions) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&options.deploymentFile, "file", "f", "", "path to the deployment file")
-	cmd.Flags().StringVarP(&options.applicationName, "application-name", "n", "", "application name for deployment")
+	cmd.Flags().StringVarP(&options.application, "application", "n", "", "application name for deployment")
 	cmd.MarkFlagRequired("file")
 	return cmd
 }
@@ -97,19 +97,19 @@ func start(cmd *cobra.Command, options *deployStartOptions, args []string) error
 	if err != nil {
 		return fmt.Errorf("error invalid deployment object: %s", err)
 	}
-	applicationNameOpt := options.applicationName
-	var applicationName string
-	if len(applicationNameOpt) > 0 {
-		applicationName = applicationNameOpt
+	applicationOpt := options.application
+	var application string
+	if len(applicationOpt) > 0 {
+		application = applicationOpt
 	} else {
-		applicationName = payload.Application
+		application = payload.Application
 	}
 
-	if len(applicationName) < 1 {
+	if len(application) < 1 {
 		return fmt.Errorf("application name must be defined in deployment file or by application-name opt")
 	}
 
-	dep, err := deployment.CreateDeploymentRequest(applicationName, &payload)
+	dep, err := deployment.CreateDeploymentRequest(application, &payload)
 	if err != nil {
 		return fmt.Errorf("error converting deployment object: %s", err)
 	}

--- a/cmd/deploy/start_test.go
+++ b/cmd/deploy/start_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"os"
@@ -202,7 +203,7 @@ func (suite *DeployStartTestSuite) TestWhenTheManifestAndFlagDoNotHaveAppNameBut
 	args := []string{
 		"deploy", "start",
 		"--file=" + tempFile.Name(),
-		"--application-name=foo",
+		"--application=foo",
 		"--output=json",
 	}
 	rootCmd.SetArgs(args)

--- a/cmd/deploy/start_test.go
+++ b/cmd/deploy/start_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"os"
@@ -161,6 +160,59 @@ func (suite *DeployStartTestSuite) TestDeployStartBadPath() {
 	suite.EqualError(err, "error trying to read the YAML file: open /badPath/test.yml: no such file or directory")
 }
 
+func (suite *DeployStartTestSuite) TestWhenTheManifestAndFlagDoNotHaveAppNameAnErrorIsRaised() {
+	expected := de.NewPipelineStartPipelineResponse()
+	expected.SetPipelineId("12345")
+	err := registerResponder(expected, 200)
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartYAMLSuccess failed with: %s", err)
+	}
+	tempFile := util.TempAppFile("", "app", testAppYamlStrWithoutApplicationName)
+	if tempFile == nil {
+		suite.T().Fatal("TestWhenTheManifestAndFlagDoNotHaveAppNameAnErrorIsRaised failed with: Could not create temp app file.")
+	}
+	suite.T().Cleanup(func() { os.Remove(tempFile.Name()) })
+	outWriter := bytes.NewBufferString("")
+	rootCmd, err := getDeployCmdWithTmpFile(outWriter, tempFile, "yaml")
+	err = rootCmd.Execute()
+	if err == nil {
+		suite.T().Fatal("TestWhenTheManifestAndFlagDoNotHaveAppNameAnErrorIsRaised failed with: error should not be null")
+	}
+	suite.EqualError(err, "application name must be defined in deployment file or by application-name opt")
+}
+
+func (suite *DeployStartTestSuite) TestWhenTheManifestAndFlagDoNotHaveAppNameButFlagIsSuppliedAnErrorIsNotRaised() {
+	expected := de.NewPipelineStartPipelineResponse()
+	expected.SetPipelineId("12345")
+	err := registerResponder(expected, 200)
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartYAMLSuccess failed with: %s", err)
+	}
+	tempFile := util.TempAppFile("", "app", testAppYamlStrWithoutApplicationName)
+	if tempFile == nil {
+		suite.T().Fatal("TestWhenTheManifestAndFlagDoNotHaveAppNameButFlagIsSuppliedAnErrorIsNotRaised failed with: Could not create temp app file.")
+	}
+	suite.T().Cleanup(func() { os.Remove(tempFile.Name()) })
+	outWriter := bytes.NewBufferString("")
+	rootCmd, options, err := getOverrideRootCmd(outWriter)
+	if err != nil {
+		suite.T().Fatalf("TestWhenTheManifestAndFlagDoNotHaveAppNameButFlagIsSuppliedAnErrorIsNotRaised failed with: %s", err)
+	}
+	rootCmd.AddCommand(NewDeployCmd(options))
+	args := []string{
+		"deploy", "start",
+		"--file=" + tempFile.Name(),
+		"--application-name=foo",
+		"--output=json",
+	}
+	rootCmd.SetArgs(args)
+
+	err = rootCmd.Execute()
+	if err != nil {
+		suite.T().Fatalf("TestWhenTheManifestAndFlagDoNotHaveAppNameButFlagIsSuppliedAnErrorIsNotRaised failed with: %s", err)
+	}
+}
+
 func getOverrideRootCmd(outWriter io.Writer) (*cobra.Command, *cmd.RootOptions, error) {
 	rootCmd, options := cmd.NewCmdRoot(outWriter, ioutil.Discard)
 	client, err := deploy.NewDeployClient(
@@ -206,6 +258,24 @@ const testAppYamlStr = `
 version: apps/v1
 kind: kubernetes
 application: deployment-test
+targets:
+    dev-west:
+        account: dev
+        namespace: test
+        strategy: strategy1
+manifests: []
+strategies:
+    strategy1:
+        canary:
+            steps:
+                - pause:
+                    duration: 1
+                    unit: SECONDS
+`
+
+const testAppYamlStrWithoutApplicationName = `
+version: apps/v1
+kind: kubernetes
 targets:
     dev-west:
         account: dev

--- a/pkg/deploy/service.go
+++ b/pkg/deploy/service.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func CreateDeploymentRequest(applicationName string, config *model.OrchestrationConfig) (*de.PipelineStartPipelineRequest, error) {
+func CreateDeploymentRequest(application string, config *model.OrchestrationConfig) (*de.PipelineStartPipelineRequest, error) {
 	environments := make([]de.PipelinePipelineEnvironment, 0, len(*config.Targets))
 	deployments := make([]de.PipelinePipelineDeployment, 0, len(*config.Targets))
 	for key, element := range *config.Targets {
@@ -62,7 +62,7 @@ func CreateDeploymentRequest(applicationName string, config *model.Orchestration
 		})
 	}
 	req := de.PipelineStartPipelineRequest{
-		Application:  &applicationName,
+		Application:  &application,
 		Environments: &environments,
 		Deployments:  &deployments,
 	}

--- a/pkg/deploy/service.go
+++ b/pkg/deploy/service.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func CreateDeploymentRequest(config *model.OrchestrationConfig) (*de.PipelineStartPipelineRequest, error) {
+func CreateDeploymentRequest(applicationName string, config *model.OrchestrationConfig) (*de.PipelineStartPipelineRequest, error) {
 	environments := make([]de.PipelinePipelineEnvironment, 0, len(*config.Targets))
 	deployments := make([]de.PipelinePipelineDeployment, 0, len(*config.Targets))
 	for key, element := range *config.Targets {
@@ -62,7 +62,7 @@ func CreateDeploymentRequest(config *model.OrchestrationConfig) (*de.PipelineSta
 		})
 	}
 	req := de.PipelineStartPipelineRequest{
-		Application:  &config.Application,
+		Application:  &applicationName,
 		Environments: &environments,
 		Deployments:  &deployments,
 	}

--- a/pkg/deploy/service_test.go
+++ b/pkg/deploy/service_test.go
@@ -125,7 +125,7 @@ func (suite *ServiceTestSuite) TestCreateDeploymentRequestSuccess() {
 		Manifests:   &manifests,
 	}
 
-	received, err := CreateDeploymentRequest(&orchestration)
+	received, err := CreateDeploymentRequest("", &orchestration)
 	if err != nil {
 		suite.T().Fatalf("TestCreateDeploymentRequestSuccess failed with: %s", err)
 	}


### PR DESCRIPTION
I want to be able to seperate application name from the _**deployment.yaml**_ file so that I can share a single deployment yaml file with many services without needed a diy tempalte render'r

This PR introduces an optional flag for specifying application name outside of the manifest file