### PR TITLE
fix(template): fix broken pause in kubernetes core template

### DIFF
--- a/cmd/template/kubernetes.go
+++ b/cmd/template/kubernetes.go
@@ -56,7 +56,7 @@ func buildTemplateKubernetesCore(options *templateCanaryOptions) (*yaml.Node, er
 	pauseNode, pauseValuesNode := util.BuildMapNode("pause", "The map key is the step type")
 	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildIntNode("duration", "1", "The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.")...)
 	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildStringNode("unit", "SECONDS", "")...)
-	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildBoolNode("untilApproved", "false",
+	pauseValuesNode.Content = append(pauseValuesNode.Content, util.BuildBoolNode("untilApproved", "true",
 		"If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set.")...)
 	pause.Content = append(pause.Content, pauseNode, pauseValuesNode)
 	afterNode, afterValuesNode := util.BuildSequenceNode("afterDeployment", "A set of steps that are executed in parallel, after the deployment is run")


### PR DESCRIPTION
<!--- Hello! Thanks for opening a pull request. This template will assist you! -->
<!--- ** Provide a general summary of your changes in the Title above using the format: -->
<!---     <type>(<scope>): <description> -->
<!---     ex. `feat(api): add route to approve deployments` -->
<!---     Note: <type> must be one of `feat`, `fix`, `chore`, `task` -->
<!---       reference: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

<!--- ** We have a Jira integration with this repository; if this work is connected to a  -->
<!---     jira ticket in progress make sure to either:  -->
<!---     a) add the jira ticket to the branch name  -->
<!---     b) add the jira ticket the body of one of the commits in this branch  -->
## Description
<!--- Describe your changes in detail, a few sentences is fine -->
The generated template from the template command had a broken pause. `untilApproved` was false so deploy engine was looking for a duration int that didn't exist.

## Motivation and Context
<!--- Jira ticket (or slack conversation link) if none provided in commit/branch -->
https://armory.atlassian.net/browse/YODL-414

## How has this been tested? How can a reviewer test these changes?
<!--- Please describe how you tested your changes, either manually or with new/existing tests. -->
<!--- If not described above, add detail on how a reviewer may test these changes themselves. -->

# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [x] Have you verified the specific change made in this PR?
