### PR TITLE
chore(scanning): fix the workflow to ensure aquasec automatically scans the cli image CDAAS-1613

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,7 @@ jobs:
     name: CVE Image Scan
     needs:
       - build-push
+      - setup
     runs-on: ubuntu-latest
     steps:
       - name: Run Security Scan


### PR DESCRIPTION
<!--- ** We have a Jira integration with this repository; if this work is connected to a  -->
<!---     jira ticket in progress make sure to either:  -->
<!---     a) add the jira ticket to the branch name  -->
<!---     b) add the jira ticket the body of one of the commits in this branch  -->
## Description
Updates the GHA release workflow to ensure the aquasec scan of the cli occurs. 
## Motivation and Context
CDAAS-1613

## How has this been tested? How can a reviewer test these changes?
We need to merge this change to test it as it only runs when main is pushed. 
# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [ ] Have you verified the specific change made in this PR?
