### PR TITLE
feat(armory.io): added support for special handling of system-defined roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ armory
 armory-cli
 .scannerwork
 scratch
+avm-darwin-amd64

--- a/cmd/config/apply.go
+++ b/cmd/config/apply.go
@@ -117,7 +117,7 @@ func processRoles(configClient *configCmd.ConfigClient, rolesFromConfig []model.
 					}
 					log.S().Infof("Updated Role: '%s'", roleInConfig.Name)
 				} else {
-					log.S().Infof("Role %s is a system defined role and cannot be updated via CLI.", roleInConfig.Name)
+					log.S().Infof("Role %s is a system role. You cannot update it via the CLI.", roleInConfig.Name)
 				}
 				break
 			}

--- a/cmd/config/apply.go
+++ b/cmd/config/apply.go
@@ -115,7 +115,7 @@ func processRoles(configClient *configCmd.ConfigClient, rolesFromConfig []model.
 					if err != nil {
 						return errorUtils.NewWrappedError(ErrUpdateRole, err)
 					}
-					log.S().Infof("Updated role: '%s'", roleInConfig.Name)
+					log.S().Infof("Updated Role: '%s'", roleInConfig.Name)
 				} else {
 					log.S().Infof("Role %s is a system defined role and cannot be updated via CLI.", roleInConfig.Name)
 				}

--- a/cmd/config/apply.go
+++ b/cmd/config/apply.go
@@ -84,7 +84,7 @@ func findDeletedRoles(rolesInConfigFile, existingRoles []model.RoleConfig) []str
 		ma[configRole.Name] = true
 	}
 	for _, existingRole := range existingRoles {
-		if !ma[existingRole.Name] {
+		if !ma[existingRole.Name] && !existingRole.SystemDefined {
 			deletedRoles = append(deletedRoles, existingRole.Name)
 		}
 	}
@@ -106,15 +106,19 @@ func processRoles(configClient *configCmd.ConfigClient, rolesFromConfig []model.
 		for _, roleInExisting := range existingRoles {
 			if roleInConfig.Name == roleInExisting.Name {
 				exists = true
-				//update existing role
-				ctx, cancel := context.WithTimeout(configClient.ArmoryCloudClient.Context, time.Minute)
-				defer cancel()
-				req, err := configCmd.UpdateRolesRequest(&roleInConfig)
-				_, _, err = configClient.UpdateRole(ctx, req)
-				if err != nil {
-					return errorUtils.NewWrappedError(ErrUpdateRole, err)
+				if !roleInExisting.SystemDefined {
+					//update existing role
+					ctx, cancel := context.WithTimeout(configClient.ArmoryCloudClient.Context, time.Minute)
+					defer cancel()
+					req, err := configCmd.UpdateRolesRequest(&roleInConfig)
+					_, _, err = configClient.UpdateRole(ctx, req)
+					if err != nil {
+						return errorUtils.NewWrappedError(ErrUpdateRole, err)
+					}
+					log.S().Infof("Updated role: '%s'", roleInConfig.Name)
+				} else {
+					log.S().Infof("Role %s is a system defined role and cannot be updated via CLI.", roleInConfig.Name)
 				}
-				log.S().Infof("Updated role: %s", roleInConfig.Name)
 				break
 			}
 		}

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -66,7 +66,7 @@ func get(cmd *cobra.Command, options *configApplyOptions, configuration *config.
 }
 
 type FormattableConfiguration struct {
-	Configuration model.ConfiguationOutput `json:"roles", yaml:"roles"`
+	Configuration model.ConfiguationOutput `json:"roles" yaml:"roles"`
 	httpResponse  *_nethttp.Response
 	err           error
 }
@@ -84,9 +84,15 @@ func (u FormattableConfiguration) GetFetchError() error {
 }
 
 func newGetConfigWrapper(rawRoles []model.RoleConfig, response *_nethttp.Response, err error) FormattableConfiguration {
+	userOnlyRoles := make([]model.RoleConfig, 0)
+	for _, role := range rawRoles {
+		if !role.SystemDefined {
+			userOnlyRoles = append(userOnlyRoles, role)
+		}
+	}
 	wrapper := FormattableConfiguration{
 		Configuration: model.ConfiguationOutput{
-			Roles: rawRoles,
+			Roles: userOnlyRoles,
 		},
 		httpResponse: response,
 		err:          err,

--- a/cmd/config/get_test.go
+++ b/cmd/config/get_test.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/armory/armory-cli/pkg/config"
+	"github.com/armory/armory-cli/pkg/model"
+	"github.com/jarcoal/httpmock"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/suite"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestConfigGetTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigGetTestSuite))
+}
+
+type ConfigGetTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ConfigGetTestSuite) SetupSuite() {
+	os.Setenv("ARMORY_CLI_TEST", "true")
+	httpmock.Activate()
+}
+
+func (suite *ConfigGetTestSuite) SetupTest() {
+	httpmock.Reset()
+}
+
+func (suite *ConfigGetTestSuite) TearDownSuite() {
+	os.Unsetenv("ARMORY_CLI_TEST")
+	httpmock.DeactivateAndReset()
+}
+
+func (suite *ConfigGetTestSuite) TestConfigGetUserRole() {
+	getExpected := []model.RoleConfig{{
+		Name:   "test",
+		Tenant: "testTenant",
+		Grants: []model.GrantConfig{{
+			Type:       "api",
+			Resource:   "org",
+			Permission: "all",
+		}},
+	}}
+
+	err := registerResponder(getExpected, http.StatusOK, "/roles", http.MethodGet)
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartJsonSuccess failed with: %s", err)
+	}
+
+	outWriter := bytes.NewBufferString("")
+	cmd := getConfigGetCmdWithTmpFile(outWriter, "json")
+	err = cmd.Execute()
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartJsonSuccess failed with: %s", err)
+	}
+	jsonContent, err := ioutil.ReadAll(outWriter)
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartJsonSuccess failed with: %s", err)
+	}
+	callCount := httpmock.GetCallCountInfo()
+	suite.Equal(1, callCount["GET /roles"])
+	result := model.ConfigurationConfig{}
+	json.Unmarshal(jsonContent, &result)
+	if len(result.Roles) != 1 {
+		suite.T().Fatalf("expected one user role to be retured!")
+	}
+}
+
+func (suite *ConfigGetTestSuite) TestConfigGetSystemRole() {
+	getExpected := []model.RoleConfig{{
+		Name:          "test",
+		Tenant:        "testTenant",
+		SystemDefined: true,
+		Grants: []model.GrantConfig{{
+			Type:       "api",
+			Resource:   "org",
+			Permission: "all",
+		}},
+	}}
+
+	err := registerResponder(getExpected, http.StatusOK, "/roles", http.MethodGet)
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartJsonSuccess failed with: %s", err)
+	}
+
+	outWriter := bytes.NewBufferString("")
+	cmd := getConfigGetCmdWithTmpFile(outWriter, "json")
+	err = cmd.Execute()
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartJsonSuccess failed with: %s", err)
+	}
+	jsonContent, err := ioutil.ReadAll(outWriter)
+	if err != nil {
+		suite.T().Fatalf("TestDeployStartJsonSuccess failed with: %s", err)
+	}
+	callCount := httpmock.GetCallCountInfo()
+	suite.Equal(1, callCount["GET /roles"])
+	result := model.ConfigurationConfig{}
+	json.Unmarshal(jsonContent, &result)
+	if len(result.Roles) != 0 {
+		suite.T().Fatalf("expected one user role to be retured!")
+	}
+}
+
+func getConfigGetCmdWithTmpFile(outWriter io.Writer, output string) *cobra.Command {
+	token := "some-token"
+	addr := "https://localhost"
+	clientId := ""
+	clientSecret := ""
+	configuration := config.New(&config.Input{
+		AccessToken:  &token,
+		ApiAddr:      &addr,
+		ClientId:     &clientId,
+		ClientSecret: &clientSecret,
+		OutFormat:    &output,
+	})
+	configApplyCmd := NewConfigGetCmd(configuration)
+	configApplyCmd.SetOut(outWriter)
+	args := []string{
+		"get",
+	}
+	configApplyCmd.SetArgs(args)
+	return configApplyCmd
+}
+
+const testGetUserRole = `
+roles:
+  - name: test
+    tenant: testTenantNew
+    grants:
+      - type: api
+        resource: org
+        permission: all
+`
+
+const testGetSystemRole = `
+roles:
+  - name: test
+    tenant: testTenantNew
+    grants:
+      - type: api
+        resource: org
+        permission: all
+`

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	github.com/t-tomalak/logrus-easy-formatter v0.0.0-20190827215021-c074f06c5816
+	go.uber.org/zap v1.23.0
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -55,7 +56,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20211109214657-ef0fda0de508 // indirect
 	golang.org/x/sys v0.0.0-20211110154304-99a53858aa08 // indirect

--- a/pkg/model/configurationConfig.go
+++ b/pkg/model/configurationConfig.go
@@ -10,9 +10,10 @@ type ConfiguationOutput struct {
 }
 
 type RoleConfig struct {
-	Name   string        `yaml:"name,omitempty"`
-	Tenant string        `yaml:"tenant,omitempty"`
-	Grants []GrantConfig `yaml:"grants,omitempty"`
+	Name          string        `yaml:"name,omitempty"`
+	Tenant        string        `yaml:"tenant,omitempty"`
+	SystemDefined bool          `yaml:"systemDefined,omitempty" json:"systemDefined,omitempty"`
+	Grants        []GrantConfig `yaml:"grants,omitempty"`
 }
 
 type GrantConfig struct {


### PR DESCRIPTION
## Description
Add handling for "systemDefined" property on the role - if there is a reole with systemDefined = true - do not allow user to modify it or delete it via CLI. 
System defined roles are not visible in the armory config get command.

## Motivation and Context
https://armory.atlassian.net/browse/CDAAS-1685

## How has this been tested? How can a reviewer test these changes?
Added dedicated unit tests to check functionality in modified get and apply commands
Tested manually against dev cluster 

# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)? N/A
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work? N/A
- [X ] Have you verified the specific change made in this PR?
