### PR TITLE
fix: fixed token leak in case of github integration flow

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -134,7 +134,7 @@ func (a *Auth) GetEnvironmentId() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return creds.Token, nil
+		return NewCredentials("", "", "", "", creds.Token, "").GetEnvironmentId()
 	}
 
 	dirname, err := os.UserHomeDir()
@@ -159,7 +159,7 @@ func (a *Auth) GetOrganizationId() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return creds.Token, nil
+		return NewCredentials("", "", "", "", creds.Token, "").GetOrganizationId()
 	}
 
 	dirname, err := os.UserHomeDir()


### PR DESCRIPTION
## Description
Fix the potential leak of entire bearer token when requesting orgId or envId in case of GitHub integration.
## Motivation and Context
security issue

## How has this been tested? How can a reviewer test these changes?
Tested on other branch along with the other piece of functionality.

# Have your performed the following tests?

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [ ] Have you verified the specific change made in this PR?
