### PR TITLE
bugfix: respect allowAutoDelete: true setting when no roles are specified explicitly

### DIFF
--- a/cmd/config/apply.go
+++ b/cmd/config/apply.go
@@ -74,10 +74,7 @@ func apply(cmd *cobra.Command, options *configApplyOptions, cli *cliconfig.Confi
 			return err
 		}
 	}
-	if payload.Roles != nil || payload.AllowAutoDelete {
-		return processRoles(cc, payload.Roles, payload.AllowAutoDelete)
-	}
-	return err
+	return processRoles(cc, payload.Roles, payload.AllowAutoDelete)
 }
 
 func processEnvironments(configClient *configuration.ConfigClient, environments []string) error {

--- a/cmd/config/apply.go
+++ b/cmd/config/apply.go
@@ -74,7 +74,7 @@ func apply(cmd *cobra.Command, options *configApplyOptions, cli *cliconfig.Confi
 			return err
 		}
 	}
-	if payload.Roles != nil {
+	if payload.Roles != nil || payload.AllowAutoDelete {
 		return processRoles(cc, payload.Roles, payload.AllowAutoDelete)
 	}
 	return err

--- a/cmd/config/apply_test.go
+++ b/cmd/config/apply_test.go
@@ -46,9 +46,11 @@ func (suite *ConfigApplyTestSuite) TestConfigApplyCreateTenant() {
 		ID:   "04f1a35f-4f55-4d3b-875d-26e35413ba76",
 		Name: "testTenant2",
 	}
+	getExpected := []model.RoleConfig{}
 
 	assert.NoError(suite.T(), registerResponder(getEnvironmentsExpected, http.StatusOK, "/environments", http.MethodGet))
 	assert.NoError(suite.T(), registerResponder(postExpected, http.StatusCreated, "/environments", http.MethodPost))
+	assert.NoError(suite.T(), registerResponder(getExpected, http.StatusOK, "/roles", http.MethodGet))
 
 	tempFile := util.TempAppFile("", "app", testConfigYamlStrForCreateTenants)
 	if tempFile == nil {
@@ -64,8 +66,9 @@ func (suite *ConfigApplyTestSuite) TestConfigApplyCreateTenant() {
 		suite.T().Fatal(err)
 	}
 	callCount := httpmock.GetCallCountInfo()
-	suite.Equal(1, callCount["GET /environments"])
+	suite.Equal(2, callCount["GET /environments"])
 	suite.Equal(1, callCount["POST /environments"])
+	suite.Equal(1, callCount["GET /roles"])
 }
 
 func (suite *ConfigApplyTestSuite) TestConfigApplyCreateRole() {

--- a/cmd/config/apply_test.go
+++ b/cmd/config/apply_test.go
@@ -307,6 +307,69 @@ func (suite *ConfigApplyTestSuite) TestConfigApplyDeleteRoleAllowAutoDelete() {
 	suite.Equal(1, callCount["PUT /roles/role-id-1"])
 }
 
+func (suite *ConfigApplyTestSuite) TestConfigApplyDeleteRoleAllowAutoDeleteButNoRolesInConfigFile() {
+	getExpected := []model.RoleConfig{{
+		ID:            "role-id-1",
+		Name:          "test",
+		EnvID:         "env-id",
+		Tenant:        "testTenant",
+		SystemDefined: true,
+		Grants: []model.GrantConfig{{
+			Type:       "api",
+			Resource:   "org",
+			Permission: "all",
+		}},
+	},
+		{
+			ID:            "role-id-2",
+			Name:          "test2",
+			EnvID:         "env-id",
+			Tenant:        "testTenant",
+			SystemDefined: false,
+			Grants: []model.GrantConfig{{
+				Type:       "api",
+				Resource:   "org",
+				Permission: "all",
+			}},
+		},
+	}
+	getEnvironmentsExpected := []configClient.Environment{{
+		Name: "testTenant",
+		ID:   "env-id",
+	}}
+	deleteExpected := model.RoleConfig{
+		Name:   "test2",
+		Tenant: "testTenant",
+		Grants: []model.GrantConfig{{
+			Type:       "api",
+			Resource:   "org",
+			Permission: "all",
+		},
+		}}
+
+	assert.NoError(suite.T(), registerResponder(getExpected, http.StatusOK, "/roles", http.MethodGet))
+	assert.NoError(suite.T(), registerResponder(getEnvironmentsExpected, http.StatusOK, "/environments", http.MethodGet))
+	assert.NoError(suite.T(), registerResponder(deleteExpected, http.StatusNoContent, "/roles/role-id-2", http.MethodDelete))
+
+	tempFile := util.TempAppFile("", "app", testConfigYamlStrForDeleteAllowAutoDeleteButNoRolesProvided)
+	if tempFile == nil {
+		suite.T().Fatal("TestDeployStartJsonSuccess failed with: Could not create temp app file.")
+	}
+	suite.T().Cleanup(func() { os.Remove(tempFile.Name()) })
+	outWriter := bytes.NewBufferString("")
+	cmd := getConfigApplyCmdWithTmpFile(outWriter, tempFile, "json")
+	if err := cmd.Execute(); err != nil {
+		suite.T().Fatal(err)
+	}
+	if _, err := io.ReadAll(outWriter); err != nil {
+		suite.T().Fatal(err)
+	}
+	callCount := httpmock.GetCallCountInfo()
+	suite.Equal(1, callCount["DELETE /roles/role-id-2"])
+	suite.Equal(1, callCount["GET /roles"])
+	suite.Equal(1, callCount["GET /environments"])
+}
+
 func (suite *ConfigApplyTestSuite) TestConfigApplyDeleteRoleDontAllowAutoDelete() {
 	getExpected := []model.RoleConfig{
 		{
@@ -452,4 +515,8 @@ roles:
 
 const testConfigYamlStrForDeleteSystemRoles = `
 roles: []
+`
+
+const testConfigYamlStrForDeleteAllowAutoDeleteButNoRolesProvided = `
+allowAutoDelete: true
 `


### PR DESCRIPTION
## Description
When user provides confiugration file like:

`
allowAutoDelete: true
`
but doesn't specify roles collection, the role processing is not taking place. 
I'd assume, that roles: [] and lack of such entry should yield the same evaluation result - empty roles collection. 

## Motivation and Context
https://armory.atlassian.net/browse/CDAAS-1989

## How has this been tested? How can a reviewer test these changes?
Added unit tests, manual testing. 

# Have your performed the following tests?

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [X] Have you verified the specific change made in this PR?
