### PR TITLE
bugfix: deploy start -w returns non-success status code on non succesfull deployment

### DIFF
--- a/cmd/deploy/start.go
+++ b/cmd/deploy/start.go
@@ -12,6 +12,7 @@ import (
 	deployment "github.com/armory/armory-cli/pkg/deploy"
 	errorUtils "github.com/armory/armory-cli/pkg/errors"
 	"github.com/armory/armory-cli/pkg/output"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	log "go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -63,6 +64,7 @@ const (
 	DeployResultDeploymentID = "DEPLOYMENT_ID"
 	DeployResultLink         = "LINK"
 	DeployResultSyncStatus   = "RUN_RESULT"
+	DeployResultStatusCode   = "STATUS_CODE"
 )
 
 var statusCheckTick = time.Second * 10
@@ -248,6 +250,7 @@ func beginTrackingDeployment(cmd *cobra.Command, configuration *config.Configura
 
 	deploy.ExecutionStatus = reportedStatus
 	storeCommandResult(cmd, DeployResultSyncStatus, reportedStatus)
+	storeCommandResult(cmd, DeployResultStatusCode, lo.Ternary(status == de.WorkflowStatusSucceeded, "0", "1"))
 }
 
 func waitForCompletion(deployClient *deployment.DeployClient, pipelineID string, canWriteProgress bool, out io.Writer) (de.WorkflowStatus, error) {

--- a/cmd/deploy/start_test.go
+++ b/cmd/deploy/start_test.go
@@ -396,9 +396,7 @@ func (suite *DeployStartTestSuite) TestDeployStartYAMLAndWaitForCompletionSucces
 	outWriter := bytes.NewBufferString("")
 	cmd := getDeployCmdWithFileName(outWriter, tempFile.Name(), "yaml", "-w")
 	err = cmd.Execute()
-	if err != nil {
-		suite.T().Fatalf("TestDeployStartYAMLSuccess failed with: %s", err)
-	}
+	suite.Error(err, "expected deployment failure due to cancelled status")
 	output, err := ioutil.ReadAll(outWriter)
 	if err != nil {
 		suite.T().Fatalf("TestDeployStartYAMLSuccess failed with: %s", err)


### PR DESCRIPTION
## Description
When starting deployment with -w flag (wait for completion), when deployment finishes with status code different than SUCCEEDED cli will propagate it to the main and will terminate with non-zero (failure) status. This will fail github action and will break any ongoing steps. 

## Motivation and Context
https://armory.atlassian.net/browse/CDAAS-2200

## How has this been tested? How can a reviewer test these changes?
Testing with local deployment. Updated unit tests.

# Have your performed the following tests?

- [X] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [X] Have you verified the specific change made in this PR?
