### PR TITLE
fix(cluster-create): A 404 can happen right after the cluster creatio…

### DIFF
--- a/cmd/cluster/cluster_create.go
+++ b/cmd/cluster/cluster_create.go
@@ -28,6 +28,7 @@ const (
 var (
 	ErrOutputTypeNotSupported = errors.New("output type is not supported. Choose type 'text' to use this feature")
 	ErrWritingSandboxSaveData = errors.New("unable to save sandbox data to file system")
+	ErrFailedToGetClusterInfo = errors.New("failed to get cluster information. Please try creating another cluster")
 )
 
 type CreateOptions struct {
@@ -96,19 +97,11 @@ func (o *CreateOptions) Run(cmd *cobra.Command) error {
 	o.InitializeProgressBar(cmd.OutOrStdout())
 	o.saveData.setAgentIdentifier(createSandboxRequest.AgentIdentifier)
 	o.saveData.setCreateSandboxResponse(*sandboxResponse)
-	var configErr *configuration.ConfigError
-	attempts := 0
+	
 	for {
 		cluster, err := o.ArmoryClient.Sandbox().Get(ctx, o.saveData.getClusterId())
-		if errors.As(err, &configErr) && attempts < 3 {
-			attempts = attempts + 1
-			if configErr.StatusCode() == 404 {
-				time.Sleep(1 * time.Second)
-				continue
-			}
-		}
 		if err != nil {
-			return err
+			return ErrFailedToGetClusterInfo
 		}
 
 		done, err := o.UpdateProgressBar(cluster)

--- a/cmd/cluster/cluster_create_test.go
+++ b/cmd/cluster/cluster_create_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/armory/armory-cli/cmd/agent"
 	"github.com/armory/armory-cli/pkg/config"
 	"github.com/armory/armory-cli/pkg/model"
@@ -59,6 +60,46 @@ func (suite *ClusterCreateTestSuite) TestCreateAndRunCommand() {
 
 	err := cmd.Execute()
 	assert.NoError(suite.T(), err)
+}
+
+func (suite *ClusterCreateTestSuite) TestGETClusterTolerates404s() {
+	credential := model.Credential{
+		ID:           "my-agent-identifier",
+		ClientSecret: "my-secret",
+		ClientId:     "my-id",
+	}
+
+	assert.NoError(suite.T(), registerResponder(credential, http.StatusCreated, "/credentials", http.MethodPost))
+	assert.NoError(suite.T(), registerResponder(rolesFromGrantStrings("my-role-id", []string{"api:agentHub:full"}, true), http.StatusOK, "/roles", http.MethodGet))
+	assert.NoError(suite.T(), registerResponder([]model.RoleConfig{}, http.StatusOK, "/credentials/my-agent-identifier/roles", http.MethodPut))
+	assert.NoError(suite.T(), registerResponder(model.CreateSandboxResponse{ClusterId: "cluster-id"}, 200, "/sandbox/clusters", http.MethodPost))
+	httpmock.RegisterResponder(http.MethodGet, "/sandbox/clusters/cluster-id",
+		httpmock.NewStringResponder(404, "{ \"error\": \"not found\"}").Times(4),
+	)
+
+	cmd := NewClusterCmd(getDefaultAppConfiguration(), getSandboxFileStore())
+	cmd.SetOut(io.Discard)
+	cmd.SetArgs([]string{
+		"create",
+	})
+
+	err := cmd.Execute()
+	suite.Equal("{ \"error\": \"not found\"}", err.Error())
+
+	info := httpmock.GetCallCountInfo()
+	fmt.Print(info)
+	suite.Equal(4, info["GET /sandbox/clusters/cluster-id"], "GET should return on its fourth 404")
+
+	httpmock.ZeroCallCounters()
+	// should fail immediately on a 500
+	httpmock.RegisterResponder(http.MethodGet, "/sandbox/clusters/cluster-id",
+		httpmock.NewStringResponder(500, "{ \"error\": \"unexpected err\"}").Times(1),
+	)
+	err = cmd.Execute()
+	suite.Equal("{ \"error\": \"unexpected err\"}", err.Error())
+	info = httpmock.GetCallCountInfo()
+	suite.Equal(1, info["GET /sandbox/clusters/cluster-id"], "GET should fail immediately on 500")
+
 }
 
 func (suite *ClusterCreateTestSuite) TestUpdateProgressBar() {

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter/v2 v2.2.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,11 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-getter/v2 v2.2.1 h1:2JXqPZs1Jej67RtdTi0YZaEB2hEFB3fkBA4cPYKQwFQ=
 github.com/hashicorp/go-getter/v2 v2.2.1/go.mod h1:EcJx6oZE8hmGuRR1l38QrfnyiujQbwsEAn11eHv6l2M=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
@@ -253,6 +256,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/configuration/agent.go
+++ b/pkg/configuration/agent.go
@@ -37,7 +37,7 @@ func (a *agents) Get(ctx context.Context, agentIdentifier string) (*model.Agent,
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	var agents []*model.Agent
@@ -68,7 +68,7 @@ func (a *agents) List(ctx context.Context) ([]model.Agent, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	var agents []model.Agent

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -63,7 +63,7 @@ func (c *ConfigClient) CreateRole(ctx context.Context, request *configClient.Cre
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, resp, &configError{response: resp}
+		return nil, resp, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -91,7 +91,7 @@ func (c *ConfigClient) UpdateRole(ctx context.Context, request *configClient.Upd
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, resp, &configError{response: resp}
+		return nil, resp, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -118,7 +118,7 @@ func (c *ConfigClient) GetRoles(ctx context.Context) ([]model.RoleConfig, *http.
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, resp, &configError{response: resp}
+		return nil, resp, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -133,16 +133,20 @@ func (c *ConfigClient) GetRoles(ctx context.Context) ([]model.RoleConfig, *http.
 	return roles, resp, nil
 }
 
-type configError struct {
+type ConfigError struct {
 	response *http.Response
 }
 
-func (d *configError) Error() string {
+func (d *ConfigError) Error() string {
 	responseBytes, err := io.ReadAll(d.response.Body)
 	if err != nil {
 		return fmt.Sprintf("could not read HTTP response body: %s", err)
 	}
 	return string(responseBytes)
+}
+
+func (d *ConfigError) StatusCode() int {
+	return d.response.StatusCode
 }
 
 func (c *ConfigClient) DeleteRole(ctx context.Context, request *configClient.DeleteRoleRequest) (*http.Response, error) {
@@ -158,7 +162,7 @@ func (c *ConfigClient) DeleteRole(ctx context.Context, request *configClient.Del
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return resp, &configError{response: resp}
+		return resp, &ConfigError{response: resp}
 	}
 
 	return resp, nil
@@ -176,7 +180,7 @@ func (c *ConfigClient) GetEnvironments(ctx context.Context) ([]configClient.Envi
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	var environments []configClient.Environment
@@ -200,7 +204,7 @@ func (c *ConfigClient) CreateEnvironment(ctx context.Context, request configClie
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, resp, &configError{response: resp}
+		return nil, resp, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)

--- a/pkg/configuration/credential.go
+++ b/pkg/configuration/credential.go
@@ -36,7 +36,7 @@ func (c *credentials) AddRoles(ctx context.Context, request *model.Credential, r
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -64,7 +64,7 @@ func (c *credentials) Create(ctx context.Context, credential *model.Credential) 
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -90,7 +90,7 @@ func (c *credentials) Delete(ctx context.Context, credential *model.Credential) 
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return &configError{response: resp}
+		return &ConfigError{response: resp}
 	}
 
 	return nil
@@ -108,7 +108,7 @@ func (c *credentials) GetRoles(ctx context.Context, credential *model.Credential
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	var roles *[]model.RoleConfig
@@ -131,7 +131,7 @@ func (c *credentials) List(ctx context.Context) ([]*model.Credential, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	var credentials []*model.Credential

--- a/pkg/configuration/role.go
+++ b/pkg/configuration/role.go
@@ -37,7 +37,7 @@ func (r *roles) ListForMachinePrincipals(ctx context.Context, environmentId stri
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)

--- a/pkg/configuration/sandbox.go
+++ b/pkg/configuration/sandbox.go
@@ -35,7 +35,7 @@ func (s *sandbox) Create(ctx context.Context, request *model.CreateSandboxReques
 	}
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -62,7 +62,7 @@ func (s *sandbox) Get(ctx context.Context, clusterId string) (*model.SandboxClus
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, &configError{response: resp}
+		return nil, &ConfigError{response: resp}
 	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)

--- a/pkg/configuration/sandbox.go
+++ b/pkg/configuration/sandbox.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"github.com/armory/armory-cli/pkg/armoryCloud"
 	"github.com/armory/armory-cli/pkg/model"
+	"github.com/hashicorp/go-retryablehttp"
 	"io"
 	"net/http"
+	"time"
 )
 
 type sandbox struct {
@@ -17,9 +19,35 @@ type sandbox struct {
 
 // newSandbox returns the API for Sandbox operations
 func newSandbox(c *ConfigClient) *sandbox {
+	client := &retryablehttp.Client{
+		HTTPClient:   c.ArmoryCloudClient.Http,
+		RetryWaitMin: 200 * time.Millisecond,
+		RetryWaitMax: 2 * time.Second,
+		RetryMax:     5,
+		CheckRetry:   SandboxRetryPolicy,
+		Backoff:      retryablehttp.DefaultBackoff,
+	}
+	c.ArmoryCloudClient.Http = client.StandardClient()
 	return &sandbox{
 		ArmoryCloudClient: c.ArmoryCloudClient,
 	}
+}
+
+func SandboxRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// do not retry on context.Canceled or context.DeadlineExceeded
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	//retryablehttp throws error after max retries, so we may find an empty resp
+	if err != nil && resp == nil {
+		return false, err
+	}
+	// don't propagate other errors
+	if resp.StatusCode >= 404 {
+		return true, err
+	}
+
+	return false, err
 }
 
 func (s *sandbox) Create(ctx context.Context, request *model.CreateSandboxRequest) (*model.CreateSandboxResponse, error) {


### PR DESCRIPTION
…n starts. Tolerate a few 404s from the API before giving up

<!--- Hello! Thanks for opening a pull request. This template will assist you! -->
<!--- ** Provide a general summary of your changes in the Title above using the format: -->
<!---     <type>(<scope>): <description> -->
<!---     ex. `feat(api): add route to approve deployments` -->
<!---     Note: <type> must be one of `feat`, `fix`, `chore`, `task` -->
<!---       reference: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

<!--- ** We have a Jira integration with this repository; if this work is connected to a  -->
<!---     jira ticket in progress make sure to either:  -->
<!---     a) add the jira ticket to the branch name  -->
<!---     b) add the jira ticket the body of one of the commits in this branch  -->
## Description
<!--- Describe your changes in detail, a few sentences is fine -->
The API tests using this feature sometimes fail because of a 404 call to `GET /cluster/:clusterId`. This seems to be the fault of us calling EC2 to get the status of the k8s cluster. There can be a briefly period where it isn't found. Let's tolerate a few 404s before considering the cluster creation a failure.  CDAAS-2228 for additional details.
## Motivation and Context
<!--- Jira ticket (or slack conversation link) if none provided in commit/branch -->
Fix flaky API test, but also help prevent a user from actually seeing this issue.

## How has this been tested? How can a reviewer test these changes?
<!--- Please describe how you tested your changes, either manually or with new/existing tests. -->
<!--- If not described above, add detail on how a reviewer may test these changes themselves. -->
New automated test and manual execution to ensure non-break change
# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [x] Have you verified the specific change made in this PR?
