### PR TITLE
feat(validation): added validate deployment yaml command

### DIFF
--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/armory/armory-cli/cmd/preview"
 	"github.com/armory/armory-cli/cmd/quickStart"
 	"github.com/armory/armory-cli/cmd/template"
+	"github.com/armory/armory-cli/cmd/validate"
 	"github.com/armory/armory-cli/cmd/version"
 	"github.com/armory/armory-cli/pkg/cmdUtils"
 	"github.com/armory/armory-cli/pkg/config"
@@ -89,6 +90,7 @@ func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, error) {
 		agent.NewCmdAgent(configuration),
 		cluster.NewClusterCmd(configuration, &cluster.SandboxClusterFileStore{}),
 		preview.NewCmdPreview(configuration),
+		validate.NewValidateCmd(configuration),
 	)
 
 	cmdUtils.SetPersistentFlagsFromEnvVariables(rootCmd.Commands())

--- a/cmd/validate/resources/pipelineRequest.cue
+++ b/cmd/validate/resources/pipelineRequest.cue
@@ -1,0 +1,216 @@
+package pipelineRequest
+
+import "list"
+import "struct"
+
+#PipelineRequest: {
+  version: string | *"v1"
+  kind: string | *"kubernetes"
+  application: string
+  deploymentConfig?: #DeploymentConfig
+  targets: [string]: #DeploymentTarget
+  targets: struct.MinFields(1)
+  targets: [string]: { strategy: or(_strategyNames) }
+  targets: [string]: {
+    constraints: #Constraints & { dependsOn?: [... or(_targetNames)]}
+  }
+  _targetNames: [ for k, v in targets {k}]
+  manifests: [... #ManifestPath & { targets?: [... or(_targetNames)] }]
+  manifests: list.MinItems(1)
+  strategies: #Strategies
+  _strategyNames: [ for k, v in strategies {k}]
+  analysis?: #PipelineAnalysisConfig
+  webhooks?: [... #WebhookConfig]
+  trafficManagement?: [... #TrafficManagement & { targets?: [... or(_targetNames)] }]
+  files?: #Files
+  contextOverrides?: [string]: string
+  targetFilters?: [... #IncludeTargetByName & { includeTarget: or(_targetNames) }]
+  targetFilters?: list.MinItems(1)
+}
+
+#TimeUnit: =~ "(?i)^none|seconds|minutes|hours$"
+#RollMode: =~ "(?i)^automatic|manual$"
+#LookbackMethod: =~ "(?i)^growing|sliding$"
+
+#DeploymentConfig: {
+  timeout: #Timeout
+}
+
+#Timeout: {
+  duration: >=1
+  unit: #TimeUnit
+}
+
+#DeploymentTarget: {
+  account: string
+  namespace?: string
+  strategy?: string
+  constraints?: #Constraints
+}
+
+#Constraints: {
+  dependsOn?: [... string]
+  dependsOn?: list.MinItems(1)
+  beforeDeployment?: [... #BeforeDeploymentStep]
+  afterDeployment?: [... #AfterDeploymentStep]
+}
+
+#BeforeDeploymentStep: #PauseStep | #WebhookStep
+#AfterDeploymentStep: #PauseStep | #WebhookStep | #AnalysisStep
+#CanaryStep: #WeightStep | #PauseStep | #WebhookStep | #AnalysisStep | #ExposeServices
+#BlueGreenCondition: #PauseStep | #WebhookStep | #AnalysisStep | #ExposeServices
+
+#ExposeServices: {
+  exposeServices: {
+    services: [... string]
+    services:  list.MinItems(1)
+    ttl?: #Timeout
+  }
+}
+
+#PauseStep: {
+  pause: {
+    untilApproved: bool
+    requiresRoles?: [... string]
+    requiresRoles?: list.MinItems(1)
+  } | {
+    duration: int
+    unit: #TimeUnit
+  }
+}
+
+#WebhookStep: {
+  runWebhook: {
+    name: string
+    context?: [string]: string
+  }
+}
+
+#WeightStep: {
+  setWeight: {
+    weight: int
+  }
+}
+
+#AnalysisStep: {
+  analysis: {
+    context?: [string]: string
+    rollBackMode: #RollMode
+    rollForwardMode: #RollMode
+    interval: >=1
+    units: #TimeUnit
+    numberOfJudgmentRuns: >=1
+    queries: [... string]
+    queries: list.MinItems(1)
+    lookbackMethod: #LookbackMethod
+    abortOnFailedJudgment?:bool
+    metricProviderName?: string
+  }
+}
+
+#ManifestPath: {
+  #PathOrInline
+  targets?: [... string]
+}
+
+#PathOrInline: {path: string} | {inline: string}
+
+#Strategies: [string]: #Strategy
+
+#Strategy: #PipelineCanaryStrategy | #PipelineBlueGreenStrategy
+
+#PipelineCanaryStrategy: {
+  canary: {
+    steps: [... #CanaryStep]
+  }
+}
+
+#PipelineBlueGreenStrategy: {
+  blueGreen: {
+    redirectTrafficAfter?: [... #BlueGreenCondition]
+    shutDownOldVersionAfter?: [... #BlueGreenCondition]
+    activeService?: string
+    previewService?: string
+  }
+}
+
+#PipelineAnalysisConfig: {
+  defaultMetricProviderName?: string
+  queries: [... #Query]
+}
+
+#Query: this={
+  name: string
+  queryTemplate: string
+  upperLimit?: float
+  lowerLimit?: float
+  #AnyOfLimits: true & list.MinItems([ for label, _ in this if list.Contains(["upperLimit", "lowerLimit"], label) {label}], 1)
+  metricProviderName?: string
+}
+
+#WebhookConfig: {
+  name: string
+  method?: string
+  uriTemplate: string
+  networkMode?: "direct" | "remoteNetworkAgent"
+  isRemoteNetworkAgent: bool | *false
+  if networkMode != _|_ {
+    isRemoteNetworkAgent: networkMode == "remoteNetworkAgent"
+  }
+  if isRemoteNetworkAgent == true {
+    agentIdentifier: string
+  }
+  headers?: [... #Header]
+  bodyTemplate?: #Body
+  retryCount?: int
+  disableCallback?: bool
+}
+
+#Header: {
+  key: string
+  value: string
+}
+
+#Body: {
+  inline: string
+}
+
+#Files: [string]: [... string]
+
+#TrafficManagement: {
+  targets?: [... string]
+  smi?: [... #SmiTrafficManagementConfig]
+  kubernetes?: [... #KubernetesTrafficManagementConfig]
+  istio?: [... #IstioTrafficManagementConfig]
+}
+
+#KubernetesTrafficManagementConfig: {
+  activeService: string
+  previewService?: string
+}
+
+#SmiTrafficManagementConfig: {
+  rootServiceName: string
+  canaryServiceName?: string
+  trafficSplitName?:  string
+}
+
+#IstioTrafficManagementConfig: {
+  virtualService: #IstioVirtualServiceConfig
+  destinationRule: #IstioDestinationRuleConfig
+}
+
+#IstioVirtualServiceConfig: {
+  name: string
+  httpRouteName?: string
+}
+
+#IstioDestinationRuleConfig: {
+  name: string
+  activeSubsetName?: string
+  canarySubsetName?: string
+}
+
+#IncludeTargetByName: {
+	includeTarget: string
+}

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -53,7 +53,7 @@ func validate(cmd *cobra.Command, configuration *config.Configuration, options *
 	if *configuration.GetIsTest() {
 		utils.ConfigureLoggingForTesting(cmd)
 	}
-	file, err := getFile(options)
+	file, err := os.ReadFile(options.deploymentFile)
 	if err != nil {
 		return err
 	}
@@ -70,14 +70,4 @@ func validate(cmd *cobra.Command, configuration *config.Configuration, options *
 		_, err = cmd.OutOrStdout().Write([]byte("YAML is valid.\n"))
 	}
 	return err
-}
-
-func getFile(options *validateOptions) ([]byte, error) {
-	//in case this is running on a GitHub instance
-	gitWorkspace, present := os.LookupEnv("GITHUB_WORKSPACE")
-	_, isATest := os.LookupEnv("ARMORY_CLI_TEST")
-	if present && !isATest {
-		options.deploymentFile = gitWorkspace + options.deploymentFile
-	}
-	return os.ReadFile(options.deploymentFile)
 }

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -1,0 +1,83 @@
+package validate
+
+import (
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	cueerrors "cuelang.org/go/cue/errors"
+	cueyaml "cuelang.org/go/encoding/yaml"
+	_ "embed"
+	"github.com/armory/armory-cli/cmd/utils"
+	"github.com/armory/armory-cli/pkg/cmdUtils"
+	"github.com/armory/armory-cli/pkg/config"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+const (
+	validateShort = "Validate deployment yaml"
+	validateLong  = "Validate deployment yaml\n\n" +
+		"For deployment configuration YAML documentation, visit https://docs.armory.io/cd-as-a-service/reference/ref-deployment-file"
+	validateExample = "armory deploy validate [options]"
+)
+
+//go:embed resources/pipelineRequest.cue
+var schemaFile []byte
+
+type validateOptions struct {
+	deploymentFile string
+}
+
+func NewValidateCmd(configuration *config.Configuration) *cobra.Command {
+	options := &validateOptions{}
+	cmd := &cobra.Command{
+		Use:     "validate --file [<path to file>]",
+		Aliases: []string{"validate"},
+		Short:   validateShort,
+		Long:    validateLong,
+		Example: validateExample,
+		GroupID: "deployment",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmdUtils.ExecuteParentHooks(cmd, args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return validate(cmd, configuration, options)
+		},
+	}
+	cmd.Flags().StringVarP(&options.deploymentFile, "file", "f", "", "path to the deployment file")
+	return cmd
+}
+
+func validate(cmd *cobra.Command, configuration *config.Configuration, options *validateOptions) error {
+	if *configuration.GetIsTest() {
+		utils.ConfigureLoggingForTesting(cmd)
+	}
+	file, err := getFile(options)
+	if err != nil {
+		return err
+	}
+	cueContext := cuecontext.New()
+	v := cueContext.CompileBytes(schemaFile)
+	schema := v.LookupPath(cue.ParsePath("#PipelineRequest"))
+	err = cueyaml.Validate(file, schema)
+	errList := cueerrors.Errors(err)
+	validationFailures := lo.Map[cueerrors.Error, string](errList, func(e cueerrors.Error, _ int) string { return e.Error() })
+	if len(validationFailures) > 0 {
+		_, err = cmd.OutOrStdout().Write([]byte("YAML is NOT valid. See the following errors:\n\n"))
+		_, err = cmd.OutOrStdout().Write([]byte(strings.Join(validationFailures, "\n\n") + "\n"))
+	} else {
+		_, err = cmd.OutOrStdout().Write([]byte("YAML is valid.\n"))
+	}
+	return err
+}
+
+func getFile(options *validateOptions) ([]byte, error) {
+	//in case this is running on a GitHub instance
+	gitWorkspace, present := os.LookupEnv("GITHUB_WORKSPACE")
+	_, isATest := os.LookupEnv("ARMORY_CLI_TEST")
+	if present && !isATest {
+		options.deploymentFile = gitWorkspace + options.deploymentFile
+	}
+	return os.ReadFile(options.deploymentFile)
+}

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -1,0 +1,134 @@
+package validate
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/armory/armory-cli/pkg/config"
+	"github.com/armory/armory-cli/pkg/util"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+)
+
+func getValidateCmdWithFileName(outWriter io.Writer, fileName string, output string, additionalOpts ...string) *cobra.Command {
+	configuration := getTestConfig(output)
+	validateCmd := NewValidateCmd(configuration)
+	validateCmd.SetOut(outWriter)
+	args := []string{
+		"--file=" + fileName,
+	}
+	args = append(args, additionalOpts...)
+	validateCmd.SetArgs(args)
+	return validateCmd
+}
+
+func getTestConfig(output string) *config.Configuration {
+	token := "some-token"
+	addr := "https://localhost"
+	clientId := ""
+	clientSecret := ""
+	isTest := true
+	configuration := config.New(&config.Input{
+		AccessToken:  &token,
+		ApiAddr:      &addr,
+		ClientId:     &clientId,
+		ClientSecret: &clientSecret,
+		OutFormat:    &output,
+		IsTest:       &isTest,
+	})
+	return configuration
+}
+
+func TestDeployValidate(t *testing.T) {
+	cases := []struct {
+		testName   string
+		deployYaml string
+		output     string
+	}{
+		{
+			testName:   "valid yaml should pass",
+			deployYaml: validDeployYamlStr,
+			output:     "YAML is valid.\n",
+		},
+		{
+			testName:   "invalid yaml should fail",
+			deployYaml: invalidDeployYamlStr,
+			output: `YAML is NOT valid. See the following errors:
+
+#PipelineRequest.targets.dev_1.strategy: 1 errors in empty disjunction:
+
+#PipelineRequest.targets.dev_1.strategy: conflicting values "strategy1" and "strategy0"
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("test-%s", c.testName), func(t *testing.T) {
+			tempFile := util.TempAppFile("", "deploy.yaml", c.deployYaml)
+			if tempFile == nil {
+				t.Fatal("TestDeployValidateSuccess failed with: Could not create temp app file.")
+			}
+			outWriter := bytes.NewBufferString("")
+			cmd := getValidateCmdWithFileName(outWriter, tempFile.Name(), "yaml")
+			err := cmd.Execute()
+			if err != nil {
+				t.Fatalf("TestDeployValidateSuccess failed with: %s", err)
+			}
+			assert.Equal(t, c.output, outWriter.String())
+		})
+	}
+
+}
+
+const validDeployYamlStr = `
+version: apps/v1
+kind: kubernetes
+application: deployment-test
+targets:
+  dev_1:
+    account: dev
+    namespace: dev-1
+    strategy: strategy1
+  dev_2:
+    account: dev
+    namespace: dev-2
+    strategy: strategy1
+    constraints: 
+      dependsOn: ["dev_1"]
+manifests:
+  - path: deployment.yaml
+strategies:
+  strategy1:
+    canary:
+      steps:
+        - pause:
+            duration: 1
+            unit: SECONDS
+`
+
+const invalidDeployYamlStr = `
+version: apps/v1
+kind: kubernetes
+application: deployment-test
+targets:
+  dev_1:
+    account: dev
+    namespace: dev-1
+    strategy: strategy0
+  dev_2:
+    account: dev
+    namespace: dev-2
+    strategy: strategy1
+    constraints: 
+    dependsOn: ["dev_1"]
+manifests:
+  - path: deployment.yaml
+strategies:
+  strategy1:
+    canary:
+      steps:
+        - pause:
+            duration: 1
+            unit: SECONDS
+`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/armory/armory-cli
 go 1.19
 
 require (
+	cuelang.org/go v0.4.3
 	github.com/ahmetb/go-linq/v3 v3.2.0
 	github.com/armory-io/deploy-engine v0.103.0
 	github.com/armory-io/preview-service v0.5.0
@@ -45,6 +46,7 @@ require (
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/cockroachdb/apd/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
@@ -99,12 +101,13 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cuelang.org/go v0.4.3 h1:W3oBBjDTm7+IZfCKZAmC8uDG0eYfJL4Pp/xbbCMKaVo=
+cuelang.org/go v0.4.3/go.mod h1:7805vR9H+VoBNdWFdI7jyDR3QLUPp4+naHfbcgp55HI=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -13,6 +15,7 @@ github.com/ahmetb/go-linq/v3 v3.2.0/go.mod h1:haQ3JfOeWK8HpVxMtHHEMPVgBKiYyQ+f1/
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armory-io/deploy-engine v0.103.0 h1:t9AiBOnviA6xwGdPIcJSS1cU+6T6iQRHKywTKalY/sY=
 github.com/armory-io/deploy-engine v0.103.0/go.mod h1:BCvWxnm2Dm8xqU5IzEMd21GwymZByM48dS3JzF43DD4=
+github.com/armory-io/deploy-engine v0.109.0/go.mod h1:Fn5Q/cVl4FAQhH6e+Lr+OwrDKJp8cmNdeHLQJQ9/Zko=
 github.com/armory-io/preview-service v0.5.0 h1:clI2Zj2mwlEYglfARe5nIA+XSEsG9n872GhVPpqjzTw=
 github.com/armory-io/preview-service v0.5.0/go.mod h1:asiLe2bmZQnapFF4ljKuPpjpzGbLlLP2PpXgpiKobxk=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
@@ -31,6 +34,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cockroachdb/apd/v2 v2.0.1 h1:y1Rh3tEU89D+7Tgbw+lp52T6p/GJLpDmNvr10UWqLTE=
+github.com/cockroachdb/apd/v2 v2.0.1/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
@@ -214,6 +219,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
+github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=
+github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -224,6 +231,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -236,6 +244,7 @@ github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
This just adds a validate deploy yaml command to the cli.
The good things about this are that it is simple and doesn't require logging in to validate yaml.
A few downsides are that the cue is duplicated from deploy engine and it may not be consistent with the de server that is running.
Some improvements that could be made would be using git subtree to bring in the cue file. If we are logged in than we could download the serverside cue file or just do the validation on the server. Still, it seems nice to have a default cue schema in this project and the ability to validate without even being online or logged in. We could also add a flag to the deploy start command to do validation there instead of as a separate command. It may also be useful to be able to use a url instead of a file like deploy start.

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [x] Have you verified the specific change made in this PR?
