### PR TITLE
task(deploy): don't validate lambda locally

### DIFF
--- a/cmd/deploy/start.go
+++ b/cmd/deploy/start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/armory/armory-cli/cmd/validate"
 	"io"
 	nethttp "net/http"
 	"os"
@@ -12,6 +11,7 @@ import (
 
 	de "github.com/armory-io/deploy-engine/pkg/api"
 	"github.com/armory/armory-cli/cmd/utils"
+	"github.com/armory/armory-cli/cmd/validate"
 	"github.com/armory/armory-cli/pkg/armoryCloud"
 	"github.com/armory/armory-cli/pkg/cmdUtils"
 	"github.com/armory/armory-cli/pkg/config"
@@ -215,28 +215,23 @@ func WithLocalFile(cmd *cobra.Command, options *deployStartOptions, deployClient
 	if present && !isATest {
 		options.deploymentFile = gitWorkspace + options.deploymentFile
 	}
-
 	// read yaml file
 	file, err := os.ReadFile(options.deploymentFile)
 	if err != nil {
 		return nil, nil, errorUtils.NewWrappedError(ErrYAMLFileRead, err)
 	}
+	validationFailures, err := validate.Validate(file)
+	if err != nil {
+		return nil, nil, errorUtils.NewWrappedError(ErrInvalidDeploymentObject, err)
+	}
 
+	validate.LogValidationErrors(cmd.OutOrStdout(), validationFailures, false)
+	cmd.SilenceUsage = true
 	// unmarshall data into struct
 	var payload map[string]any
 	if err = yaml.Unmarshal(file, &payload); err != nil {
 		return nil, nil, errorUtils.NewWrappedError(ErrInvalidDeploymentObject, err)
 	}
-
-	// TODO: because the cli's cue schema is static it doesn't validate lambda functions. For the moment lets not validate if the kind is lambda.
-	if payload["kind"] != "lambda" {
-		validationFailures := validate.Validate(file)
-		err = validate.LogValidationErrors(cmd.OutOrStdout(), validationFailures, false)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	cmd.SilenceUsage = true
 	payload["targetFilters"] = prepareTargetFilters(options)
 	ctx, cancel := context.WithTimeout(deployClient.GetArmoryCloudClient().Context, time.Minute)
 	defer cancel()

--- a/cmd/deploy/start_test.go
+++ b/cmd/deploy/start_test.go
@@ -62,7 +62,7 @@ func (suite *DeployStartTestSuite) TestDeployStart() {
 				PipelineID: "12345",
 			},
 			assertion: func(t *testing.T, result []byte, expected de.StartPipelineResponse) {
-				var received = FormattableDeployStartResponse{}
+				var received FormattableDeployStartResponse
 				assert.NoError(t, json.Unmarshal(result, &received))
 				assert.Equal(t, expected.PipelineID, received.DeploymentId)
 			},
@@ -76,7 +76,7 @@ func (suite *DeployStartTestSuite) TestDeployStart() {
 				PipelineID: "12345",
 			},
 			assertion: func(t *testing.T, result []byte, expected de.StartPipelineResponse) {
-				var received = FormattableDeployStartResponse{}
+				var received FormattableDeployStartResponse
 				assert.NoError(t, yaml.Unmarshal(result, &received))
 				assert.Equal(t, expected.PipelineID, received.DeploymentId)
 			},
@@ -106,7 +106,7 @@ func (suite *DeployStartTestSuite) TestDeployStart() {
 				assert.NotContains(t, string(result), "YAML is NOT valid. See the following errors:")
 
 				// verify that response formats as expected
-				var received = FormattableDeployStartResponse{}
+				var received FormattableDeployStartResponse
 				assert.NoError(t, yaml.Unmarshal(result, &received))
 				assert.Equal(t, expected.PipelineID, received.DeploymentId)
 			},

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -62,6 +62,11 @@ func TestDeployValidate(t *testing.T) {
 
 `,
 		},
+		{
+			testName:   "invalid lambda yaml should pass",
+			deployYaml: invalidLambdaDeployYamlStr,
+			output:     "YAML is valid.\n",
+		},
 	}
 
 	for _, c := range cases {
@@ -132,4 +137,29 @@ strategies:
         - pause:
             duration: 1
             unit: SECONDS
+`
+
+const invalidLambdaDeployYamlStr = `
+version: v1
+kind: lambda
+application: first-lambda-app
+context:
+  foo: bar
+targets:
+  firstTarget:
+    account: firstAccount
+    deployAsIamRole: "<some-deployment-role-arn>"
+    region: us-west-2
+    oops: baff
+artifacts:
+  - path: "s3://<fill-me-in>/node/v0.0.1.zip"
+    functionName: hello-lambda
+    type: zipFile
+providerOptions:
+  lambda:
+    - name: hello-lambda
+      target: firstTarget
+      runAsIamRole: "<some-lambda-role-arn>"
+      handler: index.handler
+      runtime: nodejs18.x
 `


### PR DESCRIPTION
<!--- Hello! Thanks for opening a pull request. This template will assist you! -->
<!--- ** Provide a general summary of your changes in the Title above using the format: -->
<!---     <type>(<scope>): <description> -->
<!---     ex. `feat(api): add route to approve deployments` -->
<!---     Note: <type> must be one of `feat`, `fix`, `chore`, `task` -->
<!---       reference: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

<!--- ** We have a Jira integration with this repository; if this work is connected to a  -->
<!---     jira ticket in progress make sure to either:  -->
<!---     a) add the jira ticket to the branch name  -->
<!---     b) add the jira ticket the body of one of the commits in this branch  -->
## Description
<!--- Describe your changes in detail, a few sentences is fine -->
The cue schema for the CLI doesn't know about lambda so running validation against the lambda deployments displays validation errors for users even though the lambda deployment works just fine. As the lambda feature is currently being developed it makes the most sense to simply disable validation on `deploy start` commands if the deployment type is lambda. The deployment is still being validated by the server, so this poses no risks.

## How has this been tested? How can a reviewer test these changes?
<!--- Please describe how you tested your changes, either manually or with new/existing tests. -->
<!--- If not described above, add detail on how a reviewer may test these changes themselves. -->
I've added a new test to verify that no validation errors are printed to stdout when a lambda deployment is started.

# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/dist/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/dist/darwin_amd64/armory login`) and verified the credentials work?
- [x] Have you verified the specific change made in this PR?
