### PR TITLE
fix: remove debug output from api_error

### DIFF
--- a/internal/clierr/api_error.go
+++ b/internal/clierr/api_error.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/armory/armory-cli/internal/clierr/exitcodes"
-	"github.com/armory/armory-cli/pkg/console"
 	"github.com/fatih/color"
 )
 

--- a/internal/clierr/api_error.go
+++ b/internal/clierr/api_error.go
@@ -102,7 +102,6 @@ func NewAPIError(
 // parseApiErrorFromBody makes an effort to see if the body is a well-formed api error response object.
 // It returns a pointer to the ApiErrorResponse and a boolean indicated whether the body was successfully unmarshalled
 func parseApiErrorFromBody(body []byte) (*ApiErrorResponse, bool) {
-	console.Stderrln(string(body))
 	apiError := &ApiErrorResponse{}
 	if e := json.Unmarshal(body, apiError); e != nil {
 		return nil, false


### PR DESCRIPTION
I accidentally left a debug log statement causing unwanted output
