### PR TITLE
fix(SCM): Changed SCM message to warning

### DIFF
--- a/cmd/sourceControl/scm.go
+++ b/cmd/sourceControl/scm.go
@@ -28,7 +28,7 @@ func RetrieveContext(out io.Writer, provider ServiceProvider) (Context, error) {
 	scmc, err = GithubContext{service: provider.GetGithubService()}.GetContext()
 
 	if err != nil {
-		msg := color.New(color.FgYellow, color.Bold).Sprint("scm error: ")
+		msg := color.New(color.FgYellow, color.Bold).Sprintln("\nscm warning: ")
 		fmt.Fprintf(out, "%s %s\n\n", msg, err)
 	}
 


### PR DESCRIPTION
<!--- Describe your changes in detail, a few sentences is fine -->
Changing previous error message to warning and fixing the line break.

## Motivation and Context
Current line break made it hard to find and the error word makes it look more critical than it is.

## How has this been tested? How can a reviewer test these changes?
Run in local

# Have you performed the following tests?
This doesn't change any deployment logic
