### PR TITLE
bugfix: updated version upgrade notice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,8 @@ jobs:
       - name: Build and push Docker image
         env:
           REGISTRY: docker.io
-          VERSION: ${{ steps.vars.outputs.version }}
+          VERSION: ${{ needs.setup.outputs.version }}
+          IMAGE_TAG_VERSION: ${{ steps.vars.outputs.version }}
           IMAGE_TAG: latest
           PUSH: true
         run: make release

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 APP_NAME              = armory
 APP_EXT               ?= "${CLI_EXT}"
-VERSION               ?= $(shell ./scripts/version.sh | cut -c -30) #limit the version to 30 characters -
-IMAGE_TAG_VERSION	  ?= "${VERSION}"
+VERSION               ?= $(shell ./scripts/version.sh | cut -c -30)#limit the version to 30 characters -
+IMAGE_TAG_VERSION	  ?= "$(VERSION)"
 REGISTRY              ?= armory-docker-local.jfrog.io
 REGISTRY_ORG          ?= armory
 GOARCH                ?= $(shell go env GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 APP_NAME              = armory
 APP_EXT               ?= "${CLI_EXT}"
-VERSION               ?= $(shell ./scripts/version.sh | cut -c -30) #limit the version to 30 characters - 
+VERSION               ?= $(shell ./scripts/version.sh | cut -c -30) #limit the version to 30 characters -
+IMAGE_TAG_VERSION	  ?= "${VERSION}"
 REGISTRY              ?= armory-docker-local.jfrog.io
 REGISTRY_ORG          ?= armory
 GOARCH                ?= $(shell go env GOARCH)
@@ -49,7 +50,7 @@ ifdef PUSH
 endif
 	@docker build \
 	--tag $(IMAGE):$(IMAGE_TAG) \
-	--tag $(IMAGE):$(VERSION) \
+	--tag $(IMAGE):$(IMAGE_TAG_VERSION) \
 	--label "org.opencontainers.image.created=$(TIMESTAMP)" \
 	--label "org.opencontainers.image.description=The CLI for Armory Continuous Deployments-as-a-Service" \
 	--label "org.opencontainers.image.revision=$(GITHUB_SHA)" \

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -180,7 +179,7 @@ func CheckForUpdate(cli *config.Configuration) {
 	if err != nil {
 		return
 	}
-	if ((!strings.HasSuffix(*currentRelease.TagName, currentVersion)) || (currentVersion == "development")) && cli.GetOutputType() == output.Text {
+	if ((*currentRelease.TagName != currentVersion) || (currentVersion == "development")) && cli.GetOutputType() == output.Text {
 		color.Set(color.FgGreen)
 		console.Stderrf("\nNOTICE: A new version of the Armory CLI is available. Please upgrade to %s by running `brew upgrade armory-cli` if installed with Homebrew or by running `avm install` if installed with AVM.\n\n", *currentRelease.TagName)
 		color.Unset()

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -179,7 +180,7 @@ func CheckForUpdate(cli *config.Configuration) {
 	if err != nil {
 		return
 	}
-	if ((*currentRelease.TagName != currentVersion) || (currentVersion == "development")) && cli.GetOutputType() == output.Text {
+	if ((!strings.HasSuffix(*currentRelease.TagName, currentVersion)) || (currentVersion == "development")) && cli.GetOutputType() == output.Text {
 		color.Set(color.FgGreen)
 		console.Stderrf("\nNOTICE: A new version of the Armory CLI is available. Please upgrade to %s by running `brew upgrade armory-cli` if installed with Homebrew or by running `avm install` if installed with AVM.\n\n", *currentRelease.TagName)
 		color.Unset()


### PR DESCRIPTION

## Description
Updated how the upgrade notice is displayed - the GH tag is in format "vX.Y.Z" while version stored in binary is in format "X.Y.Z". Updated the code to match the version and prvent upgrade notice from showing up in case of matching versions.

## Motivation and Context
CDAAS-241
0
## How has this been tested? How can a reviewer test these changes?

# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/bin/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/bin/darwin_amd64/armory login`) and verified the credentials work?
- [ ] Have you verified the specific change made in this PR?
