### PR TITLE
fix: make agentIdentifier optional for RNA webhooks

### DIFF
--- a/cmd/validate/resources/pipelineRequest.cue
+++ b/cmd/validate/resources/pipelineRequest.cue
@@ -161,7 +161,7 @@ import "struct"
     isRemoteNetworkAgent: networkMode == "remoteNetworkAgent"
   }
   if isRemoteNetworkAgent == true {
-    agentIdentifier: string
+    agentIdentifier?: string
   }
   headers?: [... #Header]
   bodyTemplate?: #Body

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -67,6 +67,11 @@ func TestDeployValidate(t *testing.T) {
 			deployYaml: invalidLambdaDeployYamlStr,
 			output:     "YAML is valid.\n",
 		},
+		{
+			testName:   "RNA webhook without explicit agentIdentifier should pass",
+			deployYaml: rnaWebhookWithImplicitAgent,
+			output:     "YAML is valid.\n",
+		},
 	}
 
 	for _, c := range cases {
@@ -162,4 +167,33 @@ providerOptions:
       runAsIamRole: "<some-lambda-role-arn>"
       handler: index.handler
       runtime: nodejs18.x
+`
+
+const rnaWebhookWithImplicitAgent = `
+version: apps/v1
+kind: kubernetes
+application: deployment-test
+targets:
+  dev_1:
+    account: dev
+    namespace: dev-1
+    strategy: strategy1
+    constraints:
+      afterDeployment:
+        - runWebhook:
+            name: Sample webhook
+manifests:
+  - path: deployment.yaml
+strategies:
+  strategy1:
+    canary:
+      steps:
+        - setWeight:
+            weight: 100
+webhooks:
+    - name: Sample webhook
+      method: GET
+      uriTemplate: https://webhook.site
+      networkMode: remoteNetworkAgent
+      disableCallback: true
 `


### PR DESCRIPTION
<!--- Hello! Thanks for opening a pull request. This template will assist you! -->
<!--- ** Provide a general summary of your changes in the Title above using the format: -->
<!---     <type>(<scope>): <description> -->
<!---     ex. `feat(api): add route to approve deployments` -->
<!---     Note: <type> must be one of `feat`, `fix`, `chore`, `task` -->
<!---       reference: https://www.conventionalcommits.org/en/v1.0.0/#summary -->

<!--- ** We have a Jira integration with this repository; if this work is connected to a  -->
<!---     jira ticket in progress make sure to either:  -->
<!---     a) add the jira ticket to the branch name  -->
<!---     b) add the jira ticket the body of one of the commits in this branch  -->
## Description
<!--- Describe your changes in detail, a few sentences is fine -->
`agentIdentifier` is incorrectly required when webhook's networkMode is `remoteNetworkAgent`


## How has this been tested? How can a reviewer test these changes?
<!--- Please describe how you tested your changes, either manually or with new/existing tests. -->
<!--- If not described above, add detail on how a reviewer may test these changes themselves. -->

Ran [new API test](https://github.com/armory-io/infra-armory-cloud-api-tests/pull/48) locally with CLI from this PR against https://github.com/armory-io/deploy-engine/pull/1013

# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [x] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/bin/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/bin/darwin_amd64/armory login`) and verified the credentials work?
- [x] Have you verified the specific change made in this PR?
