### PR TITLE
feat: route k8s requests with enqueueOne strategy to /pipelines endpoint

### DIFF
--- a/cmd/validate/resources/pipelineRequest.cue
+++ b/cmd/validate/resources/pipelineRequest.cue
@@ -35,6 +35,11 @@ import "struct"
 #DeploymentConfig: {
   timeout?: #Timeout
   keepDeploymentObject?: bool
+  ifDeploymentInProgress?: #IfDeploymentInProgress
+}
+
+#IfDeploymentInProgress: {
+	strategy: "reject" | "enqueueOne"
 }
 
 #Timeout: {

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -24,6 +24,7 @@ type (
 
 const (
 	mediaTypeKubernetesPipelineV2 = "application/vnd.start.kubernetes.pipeline.v2+json"
+	kubernetesKind                = "kubernetes"
 )
 
 func NewClient(configuration *config.Configuration) *Client {
@@ -173,7 +174,13 @@ func getPipelinePathAndHeaders(options StartPipelineOptions) (string, map[string
 	if err != nil {
 		return "", nil, err
 	}
-	if structured.Kind == "kubernetes" || structured.Kind == "" {
+	if structured.Kind == kubernetesKind &&
+	  structured.DeploymentConfig != nil &&
+	  structured.DeploymentConfig.IfDeploymentInProgress != nil &&
+	  structured.DeploymentConfig.IfDeploymentInProgress.Strategy == enqueueOne {
+		return "/pipelines", nil, nil
+	}
+	if structured.Kind == kubernetesKind || structured.Kind == "" {
 		return "/pipelines/kubernetes", map[string]string{
 			"Content-Type": mediaTypeKubernetesPipelineV2,
 			"Accept":       mediaTypeKubernetesPipelineV2,

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -114,6 +114,20 @@ application: lambda-application
 				"Content-Type": "application/json",
 			},
 		},
+		{
+			name: "k8s with enqueueOne strategy",
+			yaml: `
+kind: kubernetes
+application: classic-k8s-app
+deploymentConfig:
+  ifDeploymentInProgress:
+    strategy: enqueueOne
+`,
+			expectedPath: "/pipelines",
+			expectedHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/deploy/request.go
+++ b/pkg/deploy/request.go
@@ -23,9 +23,10 @@ type (
 	}
 
 	structuredConfig struct {
-		Kind        string     `yaml:"kind"`
-		Application string     `yaml:"application"`
-		Manifests   []manifest `yaml:"manifests"`
+		Kind             string            `yaml:"kind"`
+		Application      string            `yaml:"application"`
+		Manifests        []manifest        `yaml:"manifests"`
+		DeploymentConfig *deploymentConfig `yaml:"deploymentConfig"`
 	}
 
 	manifest struct {
@@ -33,6 +34,16 @@ type (
 		Targets []string `yaml:"targets"`
 		Inline  string   `yaml:"inline"`
 	}
+
+	deploymentConfig struct {
+		IfDeploymentInProgress *ifDeploymentInProgress `yaml:"ifDeploymentInProgress"`
+	}
+
+	ifDeploymentInProgress struct {
+		Strategy strategy `yaml:"strategy"`
+	}
+
+	strategy string
 )
 
 const (
@@ -41,6 +52,9 @@ const (
 	contextKey            = "context"
 	scmcKey               = "sourceControl"
 	envVarGithubWorkspace = "GITHUB_WORKSPACE"
+
+	enqueueOne strategy = "enqueueOne"
+	reject     strategy = "reject"
 )
 
 func (s *StartPipelineOptions) structuredConfig() (*structuredConfig, error) {


### PR DESCRIPTION
## Description
For deployments containing following configuration:

`   "deploymentConfig": {
       "ifDeploymentInProgress": {
           "strategy": "enqueueOne"
       }
   },`

if they are of type Kubernetes - route them to /pipelines endpoint, so they'd benefit of deployment queue functionality.

## Motivation and Context
CDAAS-2801

## How has this been tested? How can a reviewer test these changes?
added unit test, testes with staging deployment.

# Have your performed the following tests?

Please confirm you have done the following tests to ensure your pull request is ready to be merged..

- [ ] If this change modifies the deployment flow have triggered a deployment using this branch (i.e. `build/bin/darwin_amd64/armory deploy start -f <path to file>`)?
- [ ] If this change modifes the login flow have you tried logging in and out with this branch (i.e. `build/bin/darwin_amd64/armory login`) and verified the credentials work?
- [ ] Have you verified the specific change made in this PR?
